### PR TITLE
FIX: 404 error for articles from tag archives

### DIFF
--- a/themes/finley/templates/index.html
+++ b/themes/finley/templates/index.html
@@ -11,7 +11,7 @@
     {% for article in articles %}
     <article class="c-article c-article--index">
         <header class="c-article__header">
-            <h2 class="c-article__title"><a href="{{ article.url }}">{{ article.title }}</a></h2>
+            <h2 class="c-article__title"><a href="/{{ article.url }}">{{ article.title }}</a></h2>
         </header>
 
         <div class="c-article__body">


### PR DESCRIPTION
The URLs for the articles lead to a 404 error.
This commit fixes this issue by adding a leading slash to the
article URL, which is relative.